### PR TITLE
fix(multiply): Fixed [BUG-2]

### DIFF
--- a/src/operators.py
+++ b/src/operators.py
@@ -49,7 +49,7 @@ def multiply(a,b):
     Sorties :
     - float : résultat de a * b
     """
-    return a ** b
+    return a * b
 
 def divide(a,b):
     """


### PR DESCRIPTION
Changed the return operation of multiply from an exponent to a product of the input variables instead.
test_multiply in test_operators now passes.
Fixes #5 